### PR TITLE
fix: renamed meta with interval BaseName to work correctly in MergeVCFs

### DIFF
--- a/workflows/rnavar.nf
+++ b/workflows/rnavar.nf
@@ -290,7 +290,8 @@ workflow RNAVAR {
         haplotypecaller_interval_bam = bam_variant_calling.combine(ch_interval_list_split)
             .map{ meta, bam, bai, interval_list ->
                 new_meta = meta.clone()
-                new_meta.id = meta.id
+                new_meta.id = meta.id + "_" + interval_list.baseName
+                new_meta.sample = meta.id
                 [new_meta, bam, bai, interval_list]
             }
 
@@ -305,7 +306,7 @@ workflow RNAVAR {
 
         haplotypecaller_raw = GATK4_HAPLOTYPECALLER.out.vcf
             .map{ meta, vcf ->
-                meta.id = meta.id
+                meta.id = meta.sample
                 [meta, vcf]}
             .groupTuple()
 


### PR DESCRIPTION
The meta.id is now managed to include the interval baseName to run HC in parallel as well as mergeVCFs to generate sample-level  (meta.id) VCFs.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnavar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
