### PR TITLE
Fix: Call genome index if star_index is not provided

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,1 +1,4 @@
 repository_type: pipeline
+lint:
+  files_unchanged:
+    - assets/email_template.html

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+email_template.html
+.nextflow*
+work/
+data/
+results/
+.DS_Store
+testing/
+testing*
+*.pyc

--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -1,111 +1,53 @@
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- prettier-ignore -->
-    <meta name="description" content="nf-core/rnavar: GATK4 RNA variant calling pipeline" />
-    <title>nf-core/rnavar Pipeline Report</title>
-  </head>
-  <body>
-    <div style="font-family: Helvetica, Arial, sans-serif; padding: 30px; max-width: 800px; margin: 0 auto">
-      <img src="cid:nfcorepipelinelogo" />
+  <meta name="description" content="nf-core/rnavar: GATK4 RNA variant calling pipeline">
+  <title>nf-core/rnavar Pipeline Report</title>
+</head>
+<body>
+<div style="font-family: Helvetica, Arial, sans-serif; padding: 30px; max-width: 800px; margin: 0 auto;">
 
-      <h1>nf-core/rnavar v${version}</h1>
-      <h2>Run Name: $runName</h2>
+<img src="cid:nfcorepipelinelogo">
 
-      <% if (!success){ out << """
-      <div
-        style="
-          color: #a94442;
-          background-color: #f2dede;
-          border-color: #ebccd1;
-          padding: 15px;
-          margin-bottom: 20px;
-          border: 1px solid transparent;
-          border-radius: 4px;
-        "
-      >
-        <h4 style="margin-top: 0; color: inherit">nf-core/rnavar execution completed unsuccessfully!</h4>
+<h1>nf-core/rnavar v${version}</h1>
+<h2>Run Name: $runName</h2>
+
+<% if (!success){
+    out << """
+    <div style="color: #a94442; background-color: #f2dede; border-color: #ebccd1; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
+        <h4 style="margin-top:0; color: inherit;">nf-core/rnavar execution completed unsuccessfully!</h4>
         <p>The exit status of the task that caused the workflow execution to fail was: <code>$exitStatus</code>.</p>
         <p>The full error message was:</p>
-        <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0">${errorReport}</pre>
-      </div>
-      """ } else { out << """
-      <div
-        style="
-          color: #3c763d;
-          background-color: #dff0d8;
-          border-color: #d6e9c6;
-          padding: 15px;
-          margin-bottom: 20px;
-          border: 1px solid transparent;
-          border-radius: 4px;
-        "
-      >
-        nf-core/rnavar execution completed successfully!
-      </div>
-      """ } %>
-
-      <p>The workflow was completed at <strong>$dateComplete</strong> (duration: <strong>$duration</strong>)</p>
-      <p>The command used to launch the workflow was as follows:</p>
-      <pre
-        style="
-          white-space: pre-wrap;
-          overflow: visible;
-          background-color: #ededed;
-          padding: 15px;
-          border-radius: 4px;
-          margin-bottom: 30px;
-        "
-      >
-$commandLine</pre
-      >
-
-      <h3>Pipeline Configuration:</h3>
-      <table
-        style="
-          width: 100%;
-          max-width: 100%;
-          border-spacing: 0;
-          border-collapse: collapse;
-          border: 0;
-          margin-bottom: 30px;
-        "
-      >
-        <tbody style="border-bottom: 1px solid #ddd">
-          <% out << summary.collect{ k,v -> "
-          <tr>
-            <th
-              style="
-                text-align: left;
-                padding: 8px 0;
-                line-height: 1.42857143;
-                vertical-align: top;
-                border-top: 1px solid #ddd;
-              "
-            >
-              $k
-            </th>
-            <td
-              style="
-                text-align: left;
-                padding: 8px;
-                line-height: 1.42857143;
-                vertical-align: top;
-                border-top: 1px solid #ddd;
-              "
-            >
-              <pre style="white-space: pre-wrap; overflow: visible">$v</pre>
-            </td>
-          </tr>
-          " }.join("\n") %>
-        </tbody>
-      </table>
-
-      <p>nf-core/rnavar</p>
-      <p><a href="https://github.com/nf-core/rnavar">https://github.com/nf-core/rnavar</a></p>
+        <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0;">${errorReport}</pre>
     </div>
-  </body>
+    """
+} else {
+    out << """
+    <div style="color: #3c763d; background-color: #dff0d8; border-color: #d6e9c6; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
+        nf-core/rnavar execution completed successfully!
+    </div>
+    """
+}
+%>
+
+<p>The workflow was completed at <strong>$dateComplete</strong> (duration: <strong>$duration</strong>)</p>
+<p>The command used to launch the workflow was as follows:</p>
+<pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">$commandLine</pre>
+
+<h3>Pipeline Configuration:</h3>
+<table style="width:100%; max-width:100%; border-spacing: 0; border-collapse: collapse; border:0; margin-bottom: 30px;">
+    <tbody style="border-bottom: 1px solid #ddd;">
+        <% out << summary.collect{ k,v -> "<tr><th style='text-align:left; padding: 8px 0; line-height: 1.42857143; vertical-align: top; border-top: 1px solid #ddd;'>$k</th><td style='text-align:left; padding: 8px; line-height: 1.42857143; vertical-align: top; border-top: 1px solid #ddd;'><pre style='white-space: pre-wrap; overflow: visible;'>$v</pre></td></tr>" }.join("\n") %>
+    </tbody>
+</table>
+
+<p>nf-core/rnavar</p>
+<p><a href="https://github.com/nf-core/rnavar">https://github.com/nf-core/rnavar</a></p>
+
+</div>
+
+</body>
 </html>

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -104,6 +104,10 @@ workflow PREPARE_GENOME {
                 ch_star_index = file(params.star_index)
             }
         }
+        else {
+            ch_star_index   = STAR_GENOMEGENERATE(ch_fasta,ch_gtf).index
+            ch_versions     = ch_versions.mix(STAR_GENOMEGENERATE.out.versions)
+        }
 
         //if((!ch_star_index) || getIndexVersion(ch_star_index) != '2.7.4a'){
         //    ch_star_index   = STAR_GENOMEGENERATE(ch_fasta,ch_gtf).index


### PR DESCRIPTION
A commented section has blocked calling genomegenerate when star_index was not provided.
Added an else as used earlier to handle the case.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnavar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
