### PR TITLE
Fixed S3 bucket path in conditional statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added`unzip` from nf-core modules for working with unzipped fasta and gtf files
 
 ### Changed
-
 - [#95](https://github.com/nf-core/rnavar/pull/95) - Template update from nf-core/tools 2.5 -> 2.9
 - [#97](https://github.com/nf-core/rnavar/pull/97) - Template update from nf-core/tools 2.10
 - [#109](https://github.com/nf-core/rnavar/pull/109) - Update all modules
@@ -20,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#97](https://github.com/nf-core/rnavar/pull/97) - Update all gatk4 modules to disable JVM hotspot
+- [#124](https://github.com/nf-core/rnavar/pull/124) - Fixed s3 bucket path in conditional statement for SnpEff cache
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added`unzip` from nf-core modules for working with unzipped fasta and gtf files
 
 ### Changed
+
 - [#95](https://github.com/nf-core/rnavar/pull/95) - Template update from nf-core/tools 2.5 -> 2.9
 - [#97](https://github.com/nf-core/rnavar/pull/97) - Template update from nf-core/tools 2.10
 - [#109](https://github.com/nf-core/rnavar/pull/109) - Update all modules

--- a/workflows/rnavar.nf
+++ b/workflows/rnavar.nf
@@ -129,7 +129,7 @@ vep_species        = params.vep_species        ?: Channel.empty()
 // Initialize files channels based on params, not defined within the params.genomes[params.genome] scope
 if (params.snpeff_cache && params.annotate_tools && (params.annotate_tools.split(',').contains("snpeff") || params.annotate_tools.split(',').contains("merge"))) {
     def snpeff_annotation_cache_key = ''
-    if (params.snpeff_cache == "s3://annotation-cache/snpeff_cache") {
+    if (params.snpeff_cache == "s3://annotation-cache/snpeff_cache/") {
         snpeff_annotation_cache_key = "${params.snpeff_genome}.${params.snpeff_db}/"
     } else {
         snpeff_annotation_cache_key = params.use_annotation_cache_keys ? "${params.snpeff_genome}.${params.snpeff_db}/" : ""
@@ -137,7 +137,7 @@ if (params.snpeff_cache && params.annotate_tools && (params.annotate_tools.split
     def snpeff_cache_dir =  "${snpeff_annotation_cache_key}${params.snpeff_genome}.${params.snpeff_db}"
     def snpeff_cache_path_full = file("$params.snpeff_cache/$snpeff_cache_dir", type: 'dir')
     if ( !snpeff_cache_path_full.exists() || !snpeff_cache_path_full.isDirectory() ) {
-        if (params.snpeff_cache == "s3://annotation-cache/snpeff_cache") {
+        if (params.snpeff_cache == "s3://annotation-cache/snpeff_cache/") {
             error("This path is not available within annotation-cache. Please check https://annotation-cache.github.io/ to create a request for it.")
         } else {
             error("Files within --snpeff_cache invalid. Make sure there is a directory named ${snpeff_cache_dir} in ${params.snpeff_cache}.\nhttps://nf-co.re/sarek/usage#how-to-customise-snpeff-and-vep-annotation")
@@ -145,9 +145,9 @@ if (params.snpeff_cache && params.annotate_tools && (params.annotate_tools.split
     }
     snpeff_cache = Channel.fromPath(file("${params.snpeff_cache}/${snpeff_annotation_cache_key}"), checkIfExists: true).collect()
         .map{ cache -> [ [ id:"${params.snpeff_genome}.${params.snpeff_db}" ], cache ] }
-    } else if (params.annotate_tools && (params.annotate_tools.split(',').contains("snpeff") || params.annotate_tools.split(',').contains("merge")) && !params.download_cache) {
+} else if (params.annotate_tools && (params.annotate_tools.split(',').contains("snpeff") || params.annotate_tools.split(',').contains("merge")) && !params.download_cache) {
         error("No cache for SnpEff or automatic download of said cache has been detected.\nPlease refer to https://nf-co.re/sarek/docs/usage/#how-to-customise-snpeff-and-vep-annotation for more information.")
-    } else snpeff_cache = []
+} else snpeff_cache = []
 
 if (params.vep_cache && params.annotate_tools && (params.annotate_tools.split(',').contains("vep") || params.annotate_tools.split(',').contains("merge"))) {
     def vep_annotation_cache_key = ''


### PR DESCRIPTION
<!--
# nf-core/rnavar pull request

Many thanks for contributing to nf-core/rnavar!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
-->

Fixed the issue reported here: https://github.com/nf-core/rnavar/issues/121
It was a simple fix, the conditional statement wasn't working because it was missing a "/" to match the one defined in the nextflow.config, so the snpEff cache data dir wasn't being built properly.

To test it I ran the command: nextflow run ../../main.nf -profile test,docker --annotate_tools snpeff --outdir . -resume --download_cache

<img width="663" alt="image" src="https://github.com/nf-core/rnavar/assets/90359308/2943661e-834d-41b9-a624-7e5e38f16d8e">

@maxulysse There are two more issues that I spotted that the publishDir for snpEff and VEP contain a null value, I will create an issue for this address it on a separate PR

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
  - [x] If necessary, also make a PR on the nf-core/rnavar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
