### PR TITLE
Fixed VEP s3 bucket path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#97](https://github.com/nf-core/rnavar/pull/97) - Update all gatk4 modules to disable JVM hotspot
 - [#124](https://github.com/nf-core/rnavar/pull/124) - Fixed s3 bucket path in conditional statement for SnpEff cache
-- []() - Fixed s3 bucket path in conditional statement for VEP cache
+- [#127](https://github.com/nf-core/rnavar/pull/127) - Fixed s3 bucket path in conditional statement for VEP cache
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#97](https://github.com/nf-core/rnavar/pull/97) - Update all gatk4 modules to disable JVM hotspot
 - [#124](https://github.com/nf-core/rnavar/pull/124) - Fixed s3 bucket path in conditional statement for SnpEff cache
+- []() - Fixed s3 bucket path in conditional statement for VEP cache
 
 ### Dependencies
 

--- a/workflows/rnavar.nf
+++ b/workflows/rnavar.nf
@@ -151,24 +151,24 @@ if (params.snpeff_cache && params.annotate_tools && (params.annotate_tools.split
 
 if (params.vep_cache && params.annotate_tools && (params.annotate_tools.split(',').contains("vep") || params.annotate_tools.split(',').contains("merge"))) {
     def vep_annotation_cache_key = ''
-    if (params.vep_cache == "s3://annotation-cache/vep_cache") {
+    if (params.vep_cache == "s3://annotation-cache/vep_cache/") {
         vep_annotation_cache_key = "${params.vep_cache_version}_${params.vep_genome}/"
     } else {
         vep_annotation_cache_key = params.use_annotation_cache_keys ? "${params.vep_cache_version}_${params.vep_genome}/" : ""
     }
-    def vep_cache_dir = "${vep_annotation_cache_key}${params.vep_cache_version}_${params.vep_genome}/${params.vep_species}"
+    def vep_cache_dir = "${vep_annotation_cache_key}/${params.vep_species}"
     def vep_cache_path_full = file("$params.vep_cache/$vep_cache_dir", type: 'dir')
     if ( !vep_cache_path_full.exists() || !vep_cache_path_full.isDirectory() ) {
-        if (params.vep_cache == "s3://annotation-cache/vep_cache") {
+        if (params.vep_cache == "s3://annotation-cache/vep_cache/") {
             error("This path is not available within annotation-cache. Please check https://annotation-cache.github.io/ to create a request for it.")
         } else {
             error("Files within --vep_cache invalid. Make sure there is a directory named ${vep_cache_dir} in ${params.vep_cache}.\nhttps://nf-co.re/sarek/usage#how-to-customise-snpeff-and-vep-annotation")
         }
     }
     vep_cache = Channel.fromPath(file("${params.vep_cache}/${vep_annotation_cache_key}"), checkIfExists: true).collect()
-    } else if (params.annotate_tools && (params.annotate_tools.split(',').contains("vep") || params.annotate_tools.split(',').contains("merge")) && !params.download_cache) {
+} else if (params.annotate_tools && (params.annotate_tools.split(',').contains("vep") || params.annotate_tools.split(',').contains("merge")) && !params.download_cache) {
         error("No cache for VEP or automatic download of said cache has been detected.\nPlease refer to https://nf-co.re/sarek/docs/usage/#how-to-customise-snpeff-and-vep-annotation for more information.")
-    } else vep_cache = []
+} else vep_cache = []
 
 vep_extra_files = []
 


### PR DESCRIPTION
<!--
# nf-core/rnavar pull request

Many thanks for contributing to nf-core/rnavar!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
-->

The issue is described here: https://github.com/nf-core/rnavar/issues/126

I tested it with the command: 
nextflow run ../../main.nf -profile docker -c config.config --outdir . --annotate_tools merge -resume
<img width="665" alt="image" src="https://github.com/nf-core/rnavar/assets/90359308/9c95f447-782c-4626-a349-b24dc1b94319">


The config.config file contains the same values as the test profile but without the snpeff_cache and vep_cache being set to null:
```
params {
    config_profile_name        = 'Test profile'
    config_profile_description = 'Minimal test dataset to check pipeline function'

    // Limit resources so that this can run on GitHub Actions
    max_cpus   = 2
    max_memory = '6.GB'
    max_time   = '6.h'

    // Input data
    input = "${projectDir}/tests/csv/1.0/fastq_single.csv"

    // Genome references
    genome              = 'WBcel235'
    fasta               = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta'
    dict                = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.dict'
    gtf                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.gtf'

    // Known genome resources (optional)
    dbsnp               = 'https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz'
    dbsnp_tbi           = 'https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/genome/vcf/dbsnp_146.hg38.vcf.gz.tbi'
    known_indels        = 'https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/genome/vcf/mills_and_1000G.indels.vcf.gz'
    known_indels_tbi    = 'https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/genome/vcf/mills_and_1000G.indels.vcf.gz.tbi'

    // STAR index (optional)
    star_index          = 'https://github.com/nf-core/test-datasets/raw/modules/data/genomics/homo_sapiens/genome/index/star/star.tar.gz'

    // Annotation
    snpeff_db         = 105
    snpeff_genome     = 'WBcel235'
    vep_cache_version = 110
    vep_genome        = 'WBcel235'
    vep_species       = 'caenorhabditis_elegans'
}
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
  - [x] If necessary, also make a PR on the nf-core/rnavar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
