### PR TITLE
Fixed null value in publish dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#124](https://github.com/nf-core/rnavar/pull/124) - Fixed s3 bucket path in conditional statement for SnpEff cache
 - [#127](https://github.com/nf-core/rnavar/pull/127) - Fixed s3 bucket path in conditional statement for VEP cache
 - [#130](https://github.com/nf-core/rnavar/pull/130) - Added missing "def" in local variables
+- [#132](https://github.com/nf-core/rnavar/pull/132) - Added missing variantcaller key to meta map, to fix null value in publishDir
 
 ### Dependencies
 

--- a/workflows/rnavar.nf
+++ b/workflows/rnavar.nf
@@ -419,7 +419,7 @@ workflow RNAVAR {
         ch_haplotypecaller_vcf = Channel.empty()
         ch_haplotypecaller_interval_bam = ch_bam_variant_calling.combine(ch_interval_list_split)
             .map{ meta, bam, bai, interval_list ->
-                [meta + [id:meta.id + "_" + interval_list.baseName], bam, bai, interval_list, []]
+                [meta + [id:meta.id + "_" + interval_list.baseName, variantcaller:'haplotypecaller'], bam, bai, interval_list, []]
             }
 
         //


### PR DESCRIPTION
<!--
# nf-core/rnavar pull request

Many thanks for contributing to nf-core/rnavar!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
-->
This PR is to address the issue describer here: https://github.com/nf-core/rnavar/issues/125

I modified the meta_map that gets fed into the GATK4 HAPLOTYPECALLER so that it contains the key "variantcaller" that is required in the VEP and SnpEff publishDir, the same way it is implemented in nf-core/sarek, in the [haplotypecaller subworfklow](https://github.com/nf-core/sarek/blob/master/subworkflows/local/bam_variant_calling_haplotypecaller/main.nf) in line 32

I tested it with a custom dataset using this command:
```
nextflow run ../../main.nf -profile bi,cluster --input ../input_backup.csv --outdir . --annotate_tools merge -c ../config.config -resume
```
The config file only contains the path to the reference data files, and the input samplesheet contains a list of samples

This ran OK:
![image](https://github.com/nf-core/rnavar/assets/90359308/7ef6c4c1-d40d-4f6b-8ac6-6483d21ccfd4)


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
  - [x] If necessary, also make a PR on the nf-core/rnavar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
