### PR TITLE
Change gatk_vf params from integer to floats

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -505,13 +505,13 @@
                 },
                 "gatk_vf_fs_filter": {
                     "type": "number",
-                    "default": 30,
+                    "default": 30.0,
                     "description": "Value to be used for the FisherStrand (FS) filter",
                     "help_text": "This parameter defines the value to use for the FisherStrand (FS) filter in the GATK variant-filtering step. \nThe value should given in a float number format. Default is 30.0"
                 },
                 "gatk_vf_qd_filter": {
                     "type": "number",
-                    "default": 2,
+                    "default": 2.0,
                     "description": "Value to be used for the QualByDepth (QD) filter",
                     "help_text": "This parameter defines the value to use for the QualByDepth (QD) filter in the GATK variant-filtering step. \nThe value should given in a float number format. Default is 2.0"
                 }


### PR DESCRIPTION
The default qd and fs filters in the nextflow schema are integers, even though the help text (correctly) identifies that these should be floats.

At the moment, the defaults are integers. These integers can end up in the pipeline which will cause the GATK VariantFilter to fail if the input data contains variants that have fractional values for FS or QD.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnavar/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnavar _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
