### PR TITLE
Fixed dbsnp and known_indels error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#173](https://github.com/nf-core/rnavar/pull/173) - Added STAR index version control, the pipeline will now automatically detect a wrong STAR index version an create the correct index instead.
 - [#175](https://github.com/nf-core/rnavar/pull/175) - Fixed the handling of GFF files so they are now correctly being used.
 - [#177](https://github.com/nf-core/rnavar/pull/177) - Added a check and filter step for unknown regions in the exon BED. You can disable this check with `--skip_exon_bed_check`.
+- [#184](https://github.com/nf-core/rnavar/pull/184) - Added an early error when --dbsnp and/or --known_indels were missing and base recalibration wasn't turned off.
 
 ### Dependencies
 

--- a/main.nf
+++ b/main.nf
@@ -71,6 +71,10 @@ workflow NFCORE_RNAVAR {
         error("Expected --umitools_bc_pattern when --extract_umi is specified.")
     }
 
+    if(!params.skip_baserecalibration && !params.dbsnp && !params.known_indels) {
+        error("Known sites are required for performing base recalibration. Supply them with either --dbsnp and/or --known_sites or disable base recalibration with --skip_baserecalibration")
+    }
+
     // Initialize fasta file with meta map:
     ch_fasta_raw      = params.fasta                   ? Channel.fromPath(params.fasta).map{ it -> [ [id:it.baseName], it ] }.collect()        : Channel.empty()
 

--- a/workflows/rnavar.nf
+++ b/workflows/rnavar.nf
@@ -219,19 +219,21 @@ workflow RNAVAR {
             // known_sites is made by grouping both the dbsnp and the known indels ressources
             // they can either or both be optional
             def known_sites = dbsnp
-                .map { _meta, dbsnp_ -> dbsnp_ }
-                .concat(known_indels)
-                .collect()
-                .map { files ->
-                    [ [id:'known_sites'], files ]
+                .combine(known_indels)
+                .map { _meta, dbsnp_, known_indels_=[] ->
+                    def file_list = [dbsnp_]
+                    file_list.add(known_indels_)
+                    return [[id:"known_sites"], file_list.flatten().findAll { entry -> entry != [] }]
                 }
+                .collect()
             def known_sites_tbi = dbsnp_tbi
-                .map { _meta, tbi -> tbi }
-                .concat(known_indels_tbi)
-                .collect()
-                .map { files ->
-                    [ [id:'known_sites'], files ]
+                .combine(known_indels_tbi)
+                .map { _meta, dbsnp_, known_indels_=[] ->
+                    def file_list = [dbsnp_]
+                    file_list.add(known_indels_)
+                    return [[id:"known_sites"], file_list.flatten().findAll { entry -> entry != [] }]
                 }
+                .collect()
 
             def interval_list_recalib = interval_list.map{ _meta, bed -> [bed] }.flatten()
             def splitncigar_bam_bai_interval = splitncigar_bam_bai.combine(interval_list_recalib)


### PR DESCRIPTION
This adds an error message to warn the user to specify either `--dbnsp` and/or `--known_indels` when base recalibration isn't turned off. 

That case made the pipeline finish successfully but it only made it half of the way