### PR TITLE
Fix test_full profile S3 access with anonymous client

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -22,3 +22,5 @@ params {
     // No dbsnp or known_indels provided, so skip base recalibration
     skip_baserecalibration = true
 }
+
+aws.client.anonymous = true // Enable anonymous S3 access for test_full profile


### PR DESCRIPTION
## Summary

- Adds `aws.client.anonymous = true` to `conf/test_full.config` to fix 403 Access Denied errors when accessing the ngi-igenomes S3 bucket

## Details

The `test_full` profile was failing with S3 Access Denied errors because it attempts to access reference files from `s3://ngi-igenomes/igenomes/` which requires AWS credentials. This fix enables anonymous S3 access for the test_full profile, matching the pattern already used in `tests/nextflow.config`.

**Root cause:**
- The `test` profile works because it overrides `igenomes_base` to use public GitHub URLs
- The `test_full` profile uses `genome = 'GRCh38'` which defaults to the S3 bucket path
- Without `aws.client.anonymous = true`, Nextflow tries authenticated access and fails with 403

This change allows CI/CD pipelines and users to run the test_full profile without needing AWS credentials.

## Test plan

- [x] Identified the issue in commit 944585294ab8a5d18222af478fb4a3d104f0284b
- [x] Applied fix to test_full.config
- [ ] Verify test_full profile runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)