### PR TITLE
Fix --help with strict syntax mode

### DIFF
--- a/subworkflows/local/utils_nfcore_rnavar_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnavar_pipeline/main.nf
@@ -95,7 +95,7 @@ workflow PIPELINE_INITIALISATION {
         log.info(
             paramsHelp(
                 help_options,
-                params.help instanceof String ? params.help : "",
+                (params.help instanceof String && params.help != "true") ? params.help : "",
             )
         )
         exit(0)


### PR DESCRIPTION
Fix for a parsing error in Nextflow with strict syntax enabled. See status repo [results](https://github.com/nf-core/strict-syntax-health/blob/main/lint_results/prints-help-results/rnavar_help.txt):

```console
$ NXF_SYNTAX_PARSER=v2 nextflow run . --help


 N E X T F L O W   ~  version 25.12.0-edge

Launching `./main.nf` [crazy_jennings] DSL2 - revision: 5856071a2c

ERROR ~ Unable to create help message: Specified param 'true' does not exist in JSON schema.

 -- Check script 'subworkflows/local/utils_nfcore_rnavar_pipeline/main.nf' at line: 98 or see '.nextflow.log' file for more details
```

In strict syntax mode, boolean `true` was being coerced to string `"true"` and passed to `paramsHelp()`, causing it to look for a non-existent parameter. Fix was to add an explicit check to filter out the `"true"` string case.

I suspect that this will need to be ported upstream to the template, I'll check.