### PR TITLE
fix: correct inverted condition for removeunknownregions bed output selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#293](https://github.com/nf-core/rnavar/pull/293) - Rescue `idxstats` files
 - [#293](https://github.com/nf-core/rnavar/pull/293) - No more overwrite of any of the `samtools` statistics files (`idxstats`, `flagstat`, `stats`)
 - [#295](https://github.com/nf-core/rnavar/pull/295) - All tools can be selected or skipped via `params.tools` or `params.skip_tools`
+- [#308](https://github.com/nf-core/rnavar/pull/308) - Fix inverted condition in `prepare_genome` that discarded cleaned BED and deadlocked when `removeunknownregions` was skipped
 
 ### Removed
 

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -89,7 +89,7 @@ workflow PREPARE_GENOME {
 
     REMOVEUNKNOWNREGIONS(ch_remove_unknown_regions_input.join(ch_dict))
 
-    def ch_exon_bed = !('removeunknownregions' in tools) ? REMOVEUNKNOWNREGIONS.out.bed.flatten() : ch_exon_bed_input
+    def ch_exon_bed = 'removeunknownregions' in tools ? REMOVEUNKNOWNREGIONS.out.bed.flatten() : ch_exon_bed_input
 
     def ch_bcftools_annotations = bcftools_annotations
         ? channel.fromPath(bcftools_annotations).collect()

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -89,7 +89,7 @@ workflow PREPARE_GENOME {
 
     REMOVEUNKNOWNREGIONS(ch_remove_unknown_regions_input.join(ch_dict))
 
-    def ch_exon_bed = 'removeunknownregions' in tools ? REMOVEUNKNOWNREGIONS.out.bed.flatten() : ch_exon_bed_input
+    def ch_exon_bed = 'removeunknownregions' in tools ? REMOVEUNKNOWNREGIONS.out.bed : ch_exon_bed_input
 
     def ch_bcftools_annotations = bcftools_annotations
         ? channel.fromPath(bcftools_annotations).collect()

--- a/subworkflows/local/prepare_genome/tests/main.nf.test.snap
+++ b/subworkflows/local/prepare_genome/tests/main.nf.test.snap
@@ -37,7 +37,12 @@
                     ]
                 ],
                 "exon_bed": [
-                    
+                    [
+                        {
+                            "id": "genome"
+                        },
+                        "/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.bed"
+                    ]
                 ],
                 "fasta": [
                     [
@@ -105,10 +110,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-03-09T12:02:57.720693024",
+        "timestamp": "2026-05-27T13:05:33.258718691",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
         }
     },
     "only essentials": {
@@ -127,7 +132,7 @@
                         {
                             "id": "genome"
                         },
-                        "exome.bed:md5,17192418c24c524881e7d970f94a4a26"
+                        "genome.exon.bed:md5,17192418c24c524881e7d970f94a4a26"
                     ]
                 ],
                 "fasta": [
@@ -156,10 +161,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-02-06T14:25:19.474716148",
+        "timestamp": "2026-05-27T13:05:19.810958709",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.2"
         }
     }
 }


### PR DESCRIPTION
## Problem

In `subworkflows/local/prepare_genome/main.nf` line 92, the condition selecting between the cleaned and raw exon BED file is inverted:

```groovy
// Line 88: run REMOVEUNKNOWNREGIONS only when tool IS in tools list ✓
def ch_remove_unknown_regions_input = 'removeunknownregions' in tools ? ch_exon_bed_input : channel.empty()

REMOVEUNKNOWNREGIONS(ch_remove_unknown_regions_input.join(ch_dict))

// Line 92: pick the output — condition is INVERTED ✗
def ch_exon_bed = !('removeunknownregions' in tools) ? REMOVEUNKNOWNREGIONS.out.bed.flatten() : ch_exon_bed_input
```

This means:
- **Default run** (`removeunknownregions` in tools): the cleaned output of `REMOVEUNKNOWNREGIONS` is discarded; the raw unfiltered BED is passed downstream.
- **When skipped** (`--skip_tools removeunknownregions`): `REMOVEUNKNOWNREGIONS.out.bed` is empty (nothing was fed to it), so `ch_exon_bed` becomes an empty channel, causing downstream processes (e.g. `GATK4_BEDTOINTERVALLIST`) to hang or silently not run.

## Fix

Remove the `!` negation on line 92:

```groovy
def ch_exon_bed = 'removeunknownregions' in tools ? REMOVEUNKNOWNREGIONS.out.bed.flatten() : ch_exon_bed_input
```

This correctly uses the cleaned BED when `removeunknownregions` ran, and falls back to the raw input BED when it was skipped.