### PR TITLE
fix: add explicit parentheses and null guard in reports filter expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#293](https://github.com/nf-core/rnavar/pull/293) - Rescue `idxstats` files
 - [#293](https://github.com/nf-core/rnavar/pull/293) - No more overwrite of any of the `samtools` statistics files (`idxstats`, `flagstat`, `stats`)
 - [#295](https://github.com/nf-core/rnavar/pull/295) - All tools can be selected or skipped via `params.tools` or `params.skip_tools`
+- [#309](https://github.com/nf-core/rnavar/pull/309) - Fix implicit operator precedence and missing null guard in reports filter expression
 
 ### Removed
 

--- a/main.nf
+++ b/main.nf
@@ -216,7 +216,7 @@ workflow {
     publish:
     multiqc = MULTIQC.out.data.mix(MULTIQC.out.plots, MULTIQC.out.report)
     reports = channel.topic("multiqc_files").filter { _meta, _process, tool, _file ->
-        return !(tool == 'gatk4' || tool == 'snpeff' && !params.tools.split(',').contains('snpeff'))
+        return !(tool == 'gatk4' || (tool == 'snpeff' && !(params.tools && params.tools.split(',').contains('snpeff'))))
     }
 }
 

--- a/main.nf
+++ b/main.nf
@@ -216,7 +216,7 @@ workflow {
     publish:
     multiqc = MULTIQC.out.data.mix(MULTIQC.out.plots, MULTIQC.out.report)
     reports = channel.topic("multiqc_files").filter { _meta, _process, tool, _file ->
-        return !(tool == 'gatk4' || (tool == 'snpeff' && !(params.tools && params.tools.split(',').contains('snpeff'))))
+        return !(tool == 'gatk4' || (tool == 'snpeff' && !('snpeff' in tools)))
     }
 }
 


### PR DESCRIPTION
## Problem

In `main.nf` line 219, the filter expression for the `reports` publish channel has two issues:

### 1. Implicit operator precedence
```groovy
return !(tool == 'gatk4' || tool == 'snpeff' && !params.tools.split(',').contains('snpeff'))
```

Because `&&` binds tighter than `||` in Groovy, this parses as:
```groovy
return !(tool == 'gatk4' || (tool == 'snpeff' && !params.tools.split(',').contains('snpeff')))
```

The behaviour happens to be correct, but the missing parentheses make the intent ambiguous and create a maintenance hazard.

### 2. Missing null guard on `params.tools`
`params.tools` defaults to `null`. Calling `.split(',')` on `null` throws a `NullPointerException`. While this is not reachable in normal execution (snpeff only runs when `params.tools` contains `snpeff` or `merge`), it is a latent risk. The same pattern is correctly guarded elsewhere in `main.nf` (lines 119, 122):
```groovy
(params.vep_cache && params.tools && (params.tools.split(',').contains("vep") || ...))
```

## Fix

Add explicit parentheses to document intent, and add the same `params.tools &&` null guard used elsewhere:

```groovy
return !(tool == 'gatk4' || (tool == 'snpeff' && !(params.tools && params.tools.split(',').contains('snpeff'))))
```

No behaviour change in normal execution.