### PR TITLE
ci: increase nf-test runner disk volume to 40gb

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
-      - volume=60gb
+      - volume=40gb
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
+      - volume=60gb
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#310](https://github.com/nf-core/rnavar/pull/310) - Increase nf-test runner disk volume to 60gb
 - [#300](https://github.com/nf-core/rnavar/pull/300) - Update all modules and subworkflows to the latest versions in nf-core/modules
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- [#310](https://github.com/nf-core/rnavar/pull/310) - Increase nf-test runner disk volume to 60gb
 - [#284](https://github.com/nf-core/rnavar/pull/284) - Back to dev
 - [#287](https://github.com/nf-core/rnavar/pull/287) - Update all modules and subworkflows
 - [#288](https://github.com/nf-core/rnavar/pull/288) - Add meta.yml for most local modules and subworkflows
@@ -86,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#294](https://github.com/nf-core/rnavar/pull/294) - Workflow outputs for multiqc_files via topic
 - [#297](https://github.com/nf-core/rnavar/pull/297) - Improve nf-test pipeline tests setup
 - [#302](https://github.com/nf-core/rnavar/pull/302) - Template update for nf-core/tools v4.0.1
+- [#310](https://github.com/nf-core/rnavar/pull/310) - Increase nf-test runner disk volume to 60gb
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#310](https://github.com/nf-core/rnavar/pull/310) - Increase nf-test runner disk volume to 60gb
 - [#300](https://github.com/nf-core/rnavar/pull/300) - Update all modules and subworkflows to the latest versions in nf-core/modules
 
 ### Fixed
@@ -76,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
+- [#310](https://github.com/nf-core/rnavar/pull/310) - Increase nf-test runner disk volume to 60gb
 - [#284](https://github.com/nf-core/rnavar/pull/284) - Back to dev
 - [#287](https://github.com/nf-core/rnavar/pull/287) - Update all modules and subworkflows
 - [#288](https://github.com/nf-core/rnavar/pull/288) - Add meta.yml for most local modules and subworkflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#294](https://github.com/nf-core/rnavar/pull/294) - Workflow outputs for multiqc_files via topic
 - [#297](https://github.com/nf-core/rnavar/pull/297) - Improve nf-test pipeline tests setup
 - [#302](https://github.com/nf-core/rnavar/pull/302) - Template update for nf-core/tools v4.0.1
-- [#310](https://github.com/nf-core/rnavar/pull/310) - Increase nf-test runner disk volume to 60gb
+- [#310](https://github.com/nf-core/rnavar/pull/310) - Increase nf-test runner disk volume to 40gb
 
 #### Fixed
 


### PR DESCRIPTION
The default RunsOn runner disk size is 30GB, which can be insufficient when pulling multiple container images (docker, singularity) across sharded nf-test jobs.

Adds `volume=60gb` to the `runs-on` labels of the `nf-test` job, doubling the available disk space. The `nf-test-changes` and `confirm-pass` jobs are left unchanged as they do not pull containers.

See the [nf-core CI runners docs](https://nf-co.re/docs/developing/testing/ci-runners) and [RunsOn volume label docs](https://runs-on.com/configuration/job-labels/#volume) for reference.