### PR TITLE
Update all modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Old name | New name |
 | -------- | -------- |
 
+| Parameter   | Old default | New default |
+| ----------- | ----------- | ----------- |
+| vep_version | 115.2-1     | 116.0-1     |
+
 ### Modules / Subworkflows
 
 | Dependency | Old name | New name |
@@ -43,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#315](https://github.com/nf-core/rnavar/pull/315) - Back to dev
 
 #### Fixed
+
+- [#318](https://github.com/nf-core/rnavar/pull/318) - Fix LoFTEE test to validate CSQ fields instead of asserting nothing
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Parameter   | Old default | New default |
 | ----------- | ----------- | ----------- |
-| vep_version | 115.2-1     | 116.0-1     |
+| vep_version | 115.2-1     | 116.0-0     |
 
 ### Modules / Subworkflows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#318](https://github.com/nf-core/rnavar/pull/318) - Update all modules
+
 ### Fixed
 
 ### Dependencies
+
+| Dependency  | Old version | New version |
+| ----------- | ----------- | ----------- |
+| ensembl-vep | 115.2       | 116.0       |
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 | BCFTools   | 1.22    |
 | BEDTools   | 2.31.1  |
 | cat        | 9.5     |
-| EnsemblVEP | 115.2   |
+| EnsemblVEP | 116.0   |
 | FastQC     | 0.12.1  |
 | GATK       | 4.6.2.0 |
 | GffRead    | 0.12.7  |

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -28,7 +28,7 @@ params {
             gtf               = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.gtf"
             bed12             = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.bed"
             snpeff_db         = 'GRCh38.99'
-            vep_cache_version = 115
+            vep_cache_version = 116
             vep_genome        = 'GRCh38'
             vep_species       = 'homo_sapiens'
         }
@@ -208,7 +208,7 @@ params {
             gtf               = "${params.igenomes_base}/Homo_sapiens/UCSC/hg38/Annotation/Genes/genes.gtf"
             bed12             = "${params.igenomes_base}/Homo_sapiens/UCSC/hg38/Annotation/Genes/genes.bed"
             snpeff_db         = 'GRCh38.99'
-            vep_cache_version = 115
+            vep_cache_version = 116
             vep_genome        = 'GRCh38'
             vep_species       = 'homo_sapiens'
         }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -182,4 +182,8 @@ If you update images or graphics, follow the nf-core [style guidelines](https://
 
 ## Pipeline specific contribution guidelines
 
-<!-- TODO nf-core: Add any pipeline specific contribution guidelines here, such as coding styles, procedures, checklists etc. -->
+### Updating VEP modules
+
+When updating `ensemblvep/vep` module, always update the `vep_version` parameter to match the new VEP version. This parameter is used by the LoFTEE plugin to locate the VEP installation path (e.g. `/opt/conda/share/ensembl-vep-${vep_version}`).
+
+Also update `vep_cache_version` in `conf/igenomes.config` for available genomes, based on what's available on [annotation-cache](https://annotation-cache.github.io/ensemblvep/). Not all genomes may have a cache for the new version — only update those that do.

--- a/modules.json
+++ b/modules.json
@@ -17,12 +17,12 @@
                     },
                     "ensemblvep/download": {
                         "branch": "master",
-                        "git_sha": "251885fdb29eca03523d326aca5c827d1f6bdfeb",
+                        "git_sha": "db055f5f8c726a924bf51dadce3978da3bbdad7e",
                         "installed_by": ["cache_download_ensemblvep_snpeff"]
                     },
                     "ensemblvep/vep": {
                         "branch": "master",
-                        "git_sha": "251885fdb29eca03523d326aca5c827d1f6bdfeb",
+                        "git_sha": "db055f5f8c726a924bf51dadce3978da3bbdad7e",
                         "installed_by": ["vcf_annotate_ensemblvep"]
                     },
                     "fastqc": {
@@ -59,7 +59,7 @@
                     },
                     "gatk4/haplotypecaller": {
                         "branch": "master",
-                        "git_sha": "b73338eca19d798eb0ef6ed112ef4d27a30d2871",
+                        "git_sha": "7abcc95130dd0388f696002a99adeb59eca54471",
                         "installed_by": ["modules"]
                     },
                     "gatk4/intervallisttools": {
@@ -94,7 +94,7 @@
                     },
                     "htslib/bgziptabix": {
                         "branch": "master",
-                        "git_sha": "54e41f4ed3aead45054380a9befeb927612ffc91",
+                        "git_sha": "22edd7ce9462025093b25e3b55006f7720ff0d8e",
                         "installed_by": ["vcf_annotate_snpeff"]
                     },
                     "mosdepth": {

--- a/modules/nf-core/ensemblvep/download/environment.yml
+++ b/modules/nf-core/ensemblvep/download/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/ensembl-vep
-  - bioconda::ensembl-vep=115.2
+  - bioconda::ensembl-vep=116.0
   # renovate: datasource=conda depName=bioconda/perl-math-cdf
   - bioconda::perl-math-cdf=0.1
   # renovate: datasource=conda depName=bioconda/htslib

--- a/modules/nf-core/ensemblvep/download/main.nf
+++ b/modules/nf-core/ensemblvep/download/main.nf
@@ -4,8 +4,8 @@ process ENSEMBLVEP_DOWNLOAD {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ed/edd02dfaf968d06c808e3c208d5b3e86afb4259590bfa6e5499965ef3bc81881/data'
-        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:efd9a6d1c5f218a9'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/11/112b7b57f93b053ccd3f8b2f2207a5faa629fd4ea181af8e1a41a1fbd007e657/data'
+        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:c4edd3fb4a233ae6'}"
 
     input:
     tuple val(meta), val(assembly), val(species), val(cache_version)

--- a/modules/nf-core/ensemblvep/vep/environment.yml
+++ b/modules/nf-core/ensemblvep/vep/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
 dependencies:
   # renovate: datasource=conda depName=bioconda/ensembl-vep
-  - bioconda::ensembl-vep=115.2
+  - bioconda::ensembl-vep=116.0
   # renovate: datasource=conda depName=bioconda/perl-math-cdf
   - bioconda::perl-math-cdf=0.1
   # renovate: datasource=conda depName=bioconda/htslib

--- a/modules/nf-core/ensemblvep/vep/main.nf
+++ b/modules/nf-core/ensemblvep/vep/main.nf
@@ -4,8 +4,8 @@ process ENSEMBLVEP_VEP {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ed/edd02dfaf968d06c808e3c208d5b3e86afb4259590bfa6e5499965ef3bc81881/data'
-        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:efd9a6d1c5f218a9'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/11/112b7b57f93b053ccd3f8b2f2207a5faa629fd4ea181af8e1a41a1fbd007e657/data'
+        : 'community.wave.seqera.io/library/ensembl-vep_perl-math-cdf_htslib:c4edd3fb4a233ae6'}"
 
     input:
     tuple val(meta), path(vcf), path(custom_extra_files)

--- a/modules/nf-core/gatk4/haplotypecaller/main.nf
+++ b/modules/nf-core/gatk4/haplotypecaller/main.nf
@@ -61,7 +61,7 @@ process GATK4_HAPLOTYPECALLER {
 
     def stub_realigned_bam = bamout_command ? "touch ${prefix.replaceAll('.g\\s*$', '')}.realigned.bam" : ""
     """
-    echo | gzip > ${prefix}.vcf.gz
+    echo "" | gzip > ${prefix}.vcf.gz
     touch ${prefix}.vcf.gz.tbi
     ${stub_realigned_bam}
     """

--- a/modules/nf-core/htslib/bgziptabix/main.nf
+++ b/modules/nf-core/htslib/bgziptabix/main.nf
@@ -55,7 +55,7 @@ process HTSLIB_BGZIPTABIX {
             ${bgzip_cmd} ;;
         *gzip-compressed*)
             [ "\$(basename ${infile})" == "\$(basename ${outfile})" ] && echo "Input and output names cannot be the same" && exit 1
-            zcat  ${infile} | ${compress_cmd} > ${outfile} ;;
+            bgzip -d -c -@ ${task.cpus} ${infile} | ${compress_cmd} > ${outfile} ;;
         *bzip2-compressed*)
             bzcat ${infile} | ${compress_cmd} > ${outfile} ;;
         *XZ-compressed*)

--- a/nextflow.config
+++ b/nextflow.config
@@ -77,7 +77,7 @@ params {
     vep_dbnsfp                   = null  // dbnsfp plugin disabled within VEP
     vep_include_fasta            = false // Don't use fasta file for annotation with VEP
     vep_loftee                   = null  // loftee plugin disabled within VEP
-    vep_version                  = "115.2-1" // Should reflect the VEP version used in the container; needed for loftee_path
+    vep_version                  = "116.0-0" // Should reflect the VEP version used in the container; needed for loftee_path
     vep_out_format               = "vcf"
     vep_cache_preflight_check    = false // No preflight check by default
     vep_spliceai                 = null  // spliceai plugin disabled within VEP

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -360,7 +360,7 @@
                 },
                 "vep_version": {
                     "type": "string",
-                    "default": "115.2-1",
+                    "default": "116.0-0",
                     "fa_icon": "fas fa-toolbox",
                     "description": "Should reflect the VEP version used in the container.",
                     "help_text": "Used by the loftee plugin which needs the full path to the VEP installation (e.g. `/opt/conda/share/ensembl-vep-${vep_version}`). Update this when the VEP container version changes."

--- a/tests/annotation_merge.nf.test.snap
+++ b/tests/annotation_merge.nf.test.snap
@@ -4,7 +4,7 @@
             12,
             {
                 "ENSEMBLVEP_VEP": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 },
@@ -124,10 +124,10 @@
             ],
             "No warnings"
         ],
-        "timestamp": "2026-06-02T10:14:55.066427973",
+        "timestamp": "2026-07-07T10:38:20.020420284",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.4"
         }
     },
     "-profile test --tools merge": {
@@ -135,7 +135,7 @@
             11,
             {
                 "ENSEMBLVEP_VEP": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 },
@@ -242,10 +242,10 @@
             ],
             "No warnings"
         ],
-        "timestamp": "2026-06-02T10:14:10.608788984",
+        "timestamp": "2026-07-07T10:37:27.116657992",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.4"
         }
     }
 }

--- a/tests/annotation_vep.nf.test
+++ b/tests/annotation_vep.nf.test
@@ -39,6 +39,7 @@ nextflow_pipeline {
                 tools: 'vep',
                 vep_loftee: true,
             ],
+            check_loftee: true,
         ],
     ]
 

--- a/tests/annotation_vep.nf.test
+++ b/tests/annotation_vep.nf.test
@@ -39,7 +39,7 @@ nextflow_pipeline {
                 tools: 'vep',
                 vep_loftee: true,
             ],
-            check_loftee: true,
+            vcf_header_check: '|LoF|',
         ],
     ]
 

--- a/tests/annotation_vep.nf.test.snap
+++ b/tests/annotation_vep.nf.test.snap
@@ -72,10 +72,12 @@
             [
                 "test_VEP.ann.vcf.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
-            "LoFTEE CSQ fields present: true",
+            [
+                "test_VEP.ann.vcf.gz:header.contains(|LoF|),true"
+            ],
             "No warnings"
         ],
-        "timestamp": "2026-07-07T11:56:24.609794682",
+        "timestamp": "2026-07-07T13:45:28.758898064",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.4"

--- a/tests/annotation_vep.nf.test.snap
+++ b/tests/annotation_vep.nf.test.snap
@@ -4,7 +4,7 @@
             9,
             {
                 "ENSEMBLVEP_VEP": {
-                    "ensemblvep": "115.2",
+                    "ensemblvep": "116.0",
                     "perl-math-cdf": "0.1",
                     "tabix": "1.23.1"
                 },
@@ -72,12 +72,13 @@
             [
                 "test_VEP.ann.vcf.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
+            "LoFTEE CSQ fields present: true",
             "No warnings"
         ],
-        "timestamp": "2026-06-01T12:49:50.70786988",
+        "timestamp": "2026-07-07T11:56:24.609794682",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.4"
         }
     },
     "Fails with profile test --dbnsfp and no dbnsfp_tbi": {

--- a/tests/lib/UTILS.groovy
+++ b/tests/lib/UTILS.groovy
@@ -58,6 +58,15 @@ class UTILS {
             assertion.add(recal_bam_files.isEmpty() ? 'No unstable recal BAM files' : recal_bam_files.collect { file -> file.tokenize('/').last() + ":stats" + bam(absolutePath(file)).getStatistics() })
             assertion.add(cram_files.isEmpty() ? 'No CRAM files' : cram_files.collect { file -> file.tokenize('/').last() + ":md5," + cram(absolutePath(file), fasta).readsMD5 })
             assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> file.tokenize('/').last() + ":md5," + path(absolutePath(file)).vcf.variantsMD5 })
+
+            // Check for LoFTEE annotations if requested
+            if (scenario.check_loftee && !vcf_files.isEmpty()) {
+                def vcf_file = vcf_files.find { it.toString().contains('VEP') }
+                if (vcf_file) {
+                    def has_loftee = path(absolutePath(vcf_file)).vcf.header.toString().contains('|LoF|')
+                    assertion.add("LoFTEE CSQ fields present: ${has_loftee}")
+                }
+            }
         }
 
         // If we have a snapshot options in scenario then we allow to capture either stderr, stdout or both

--- a/tests/lib/UTILS.groovy
+++ b/tests/lib/UTILS.groovy
@@ -59,13 +59,9 @@ class UTILS {
             assertion.add(cram_files.isEmpty() ? 'No CRAM files' : cram_files.collect { file -> file.tokenize('/').last() + ":md5," + cram(absolutePath(file), fasta).readsMD5 })
             assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> file.tokenize('/').last() + ":md5," + path(absolutePath(file)).vcf.variantsMD5 })
 
-            // Check for LoFTEE annotations if requested
-            if (scenario.check_loftee && !vcf_files.isEmpty()) {
-                def vcf_file = vcf_files.find { it.toString().contains('VEP') }
-                if (vcf_file) {
-                    def has_loftee = path(absolutePath(vcf_file)).vcf.header.toString().contains('|LoF|')
-                    assertion.add("LoFTEE CSQ fields present: ${has_loftee}")
-                }
+            // Check for specific VCF header fields if requested
+            if (scenario.vcf_header_check) {
+                assertion.add(vcf_files.isEmpty() ? 'No VCF files' : vcf_files.collect { file -> file.tokenize('/').last() + ":header.contains(${scenario.vcf_header_check})," + path(absolutePath(file)).vcf.header.toString().contains(scenario.vcf_header_check) })
             }
         }
 


### PR DESCRIPTION
Update all modules to latest versions.

## Changes

### Modules

- ensemblvep 115.2 → 116.0 (download, vep)

### Configuration

- vep_version: 115.2-1 → 116.0-1
- vep_cache_version: 115 → 116 for GRCh38/hg38

### Documentation

- CONTRIBUTING.md: Add VEP update guidelines (vep_version + igenomes.config)
- README.md: Update EnsemblVEP version

### Tests

- Add generic vcf_header_check assertion for VCF header validation

Generated via opencode.
Edited by @maxulysse 