### PR TITLE
Add riker multi for QC metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#319](https://github.com/nf-core/rnavar/pull/319) - Add riker multi for QC metrics on BAM files
+
 ### Changed
 
 - [#318](https://github.com/nf-core/rnavar/pull/318) - Update all modules
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Dependency  | Old version | New version |
 | ----------- | ----------- | ----------- |
 | ensembl-vep | 115.2       | 116.0       |
+| riker       |             | 0.4.0       |
 
 ### Parameters
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 | Mosdepth   | 0.3.10  |
 | MultiQC    | 1.33    |
 | Picard     | 3.4.0   |
+| Riker      | 0.4.0   |
 | SAMtools   | 1.22.1  |
 | Seq2HLA    | 2.3     |
 | SnpEff     | 5.3.0a  |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -182,8 +182,33 @@ If you update images or graphics, follow the nf-core [style guidelines](https://
 
 ## Pipeline specific contribution guidelines
 
-### Updating VEP modules
+### Adding or updating modules/tools
+
+When adding or updating a module/tool, you **must** update the dependencies table in `CHANGELOG.md` with the tool name and version.
+When adding or updating a tool, you **must** update the tools table in `README.md` with the tool name and version.
+
+#### Updating VEP modules
 
 When updating `ensemblvep/vep` module, always update the `vep_version` parameter to match the new VEP version. This parameter is used by the LoFTEE plugin to locate the VEP installation path (e.g. `/opt/conda/share/ensembl-vep-${vep_version}`).
 
 Also update `vep_cache_version` in `conf/igenomes.config` for available genomes, based on what's available on [annotation-cache](https://annotation-cache.github.io/ensemblvep/). Not all genomes may have a cache for the new version — only update those that do.
+
+### Updating parameters default values
+
+When updating a default value for a parameter, you **must** add an entry to the Parameters table in `CHANGELOG.md` with the old and new values.
+
+### Renaming parameters
+
+When renaming a parameter, you **must** add an entry to the Parameters table in `CHANGELOG.md` with the old and new names.
+
+### Adding or renaming subworkflows
+
+When adding or renaming a module or subworkflow, you **must** add an entry to the Subworkflows table in `CHANGELOG.md`.
+
+### Adding or updating plugins
+
+When adding or updating a plugin, you **must** add an entry to the Plugins table in `CHANGELOG.md` with the old and new versions.
+
+### Developer section in CHANGELOG
+
+When making changes that are only relevant to developers (e.g. CI improvements, test updates, code refactoring), add an entry to the Developer section in `CHANGELOG.md`.

--- a/modules.json
+++ b/modules.json
@@ -114,6 +114,12 @@
                         "installed_by": ["bam_markduplicates_picard"],
                         "patch": "modules/nf-core/picard/markduplicates/picard-markduplicates.diff"
                     },
+                    "riker/multi": {
+                        "branch": "master",
+                        "git_sha": "89b094a1b914b1e0844b4c0cc901cda5eddd569b",
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/riker/multi/riker-multi.diff"
+                    },
                     "samtools/faidx": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",

--- a/modules/nf-core/riker/multi/environment.yml
+++ b/modules/nf-core/riker/multi/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::riker=0.4.0

--- a/modules/nf-core/riker/multi/main.nf
+++ b/modules/nf-core/riker/multi/main.nf
@@ -1,0 +1,98 @@
+process RIKER_MULTI {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/54/54c7820b49cfb5fada32c1825ac8a46c05d0085105c50055cbce4c37701ab95e/data' :
+        'community.wave.seqera.io/library/riker:0.4.0--4e7eeb0beed906c0' }"
+
+    input:
+    tuple val(meta),  path(bam), path(bai), path(error_vcf), path(error_vcf_idx), path(error_intervals), path(gcbias_exclude_intervals), path(hybcap_baits, stageAs: 'baits/*'), path(hybcap_targets, stageAs: 'targets/*'), path(rna_gene_model), path(rna_ribosomal_intervals), path(wgs_intervals)
+    tuple val(meta2), path(fasta), path(fai)
+
+    output:
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.alignment-metrics.txt"),          emit: alignment_metrics,         optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.base-distribution-by-cycle.txt"), emit: base_dist,                 optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.error-indel.txt"),                emit: error_indel,               optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.error-mismatch.txt"),             emit: error_mismatch,            optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.error-overlap.txt"),              emit: error_overlap,             optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.gcbias-detail.txt"),              emit: gcbias_detail,             optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.gcbias-summary.txt"),             emit: gcbias_summary,            optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.hybcap-metrics.txt"),             emit: hybcap_metrics,            optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.hybcap-per-base.txt*"),           emit: hybcap_per_base,           optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.hybcap-per-target.txt"),          emit: hybcap_per_target,         optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.isize-histogram.txt"),            emit: isize_histogram,           optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.isize-metrics.txt"),              emit: isize_metrics,             optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.mean-quality-by-cycle.txt"),      emit: mean_qual,                 optional: true, topic: multiqc_files
+    tuple val(meta), path("*.pdf"),                            emit: pdf,                       optional: true
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.quality-score-distribution.txt"), emit: qual_dist,                 optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-biotype.txt"),                emit: rna_biotype,               optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-insert-size-histogram.txt"),  emit: rna_insert_size_histogram, optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-insert-size.txt"),            emit: rna_insert_size,           optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-metrics.txt"),                emit: rna_metrics,               optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.wgs-coverage.txt"),               emit: wgs_coverage,              optional: true, topic: multiqc_files
+    tuple val(meta), val("${task.process}"), val('riker'), path("*.wgs-metrics.txt"),                emit: wgs_metrics,               optional: true, topic: multiqc_files
+    tuple val("${task.process}"), val('riker'), eval("riker --version 2>&1 | sed 's/riker //'") , topic: versions, emit: versions_riker
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args        = task.ext.args ?: ''
+    def prefix      = task.ext.prefix ?: "${meta.id}"
+    def reference_arg = fasta ? "--reference ${fasta}" : ''
+    if ((hybcap_baits as Boolean) ^ (hybcap_targets as Boolean)) {
+        error "RIKER_MULTI: both 'baits' and 'targets' must be provided together, or neither"
+    }
+    def error_vcf_arg = error_vcf && error_vcf_idx ? "--error::vcf ${error_vcf}" : ''
+    def error_intervals_arg = error_intervals ? "--error::intervals ${error_intervals}" : ''
+    def gcbias_exclude_intervals_arg = gcbias_exclude_intervals ? "--gcbias::exclude-intervals ${gcbias_exclude_intervals}" : ''
+    def hybcap_opts = (hybcap_baits && hybcap_targets) ? "--hybcap::baits ${hybcap_baits} --hybcap::targets ${hybcap_targets}" : ''
+    def rna_gene_model_arg = rna_gene_model ? "--rna::gene-model ${rna_gene_model}" : ''
+    def rna_ribosomal_intervals_arg = rna_ribosomal_intervals ? "--rna::ribosomal-intervals ${rna_ribosomal_intervals}" : ''
+    def wgs_intervals_arg = wgs_intervals ? "--wgs::intervals ${wgs_intervals}" : ''
+
+    """
+    riker multi \\
+        -i ${bam} \\
+        ${reference_arg} \\
+        -o ${prefix} \\
+        --threads ${task.cpus} \\
+        ${hybcap_opts} \\
+        ${error_vcf_arg} \\
+        ${error_intervals_arg} \\
+        ${gcbias_exclude_intervals_arg} \\
+        ${rna_gene_model_arg} \\
+        ${rna_ribosomal_intervals_arg} \\
+        ${wgs_intervals_arg} \\
+        ${args}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.alignment-metrics.txt
+    touch ${prefix}.base-distribution-by-cycle.txt
+    touch ${prefix}.mean-quality-by-cycle.txt
+    touch ${prefix}.quality-score-distribution.txt
+    touch ${prefix}.error-mismatch.txt
+    touch ${prefix}.error-overlap.txt
+    touch ${prefix}.error-indel.txt
+    touch ${prefix}.gcbias-detail.txt
+    touch ${prefix}.gcbias-summary.txt
+    touch ${prefix}.hybcap-metrics.txt
+    touch ${prefix}.hybcap-per-target.txt
+    touch ${prefix}.hybcap-per-base.txt
+    touch ${prefix}.isize-metrics.txt
+    touch ${prefix}.isize-histogram.txt
+    touch ${prefix}.wgs-metrics.txt
+    touch ${prefix}.wgs-coverage.txt
+    touch ${prefix}.base-distribution-by-cycle.pdf
+    touch ${prefix}.gcbias-chart.pdf
+    touch ${prefix}.isize-histogram.pdf
+    touch ${prefix}.mean-quality-by-cycle.pdf
+    touch ${prefix}.quality-score-distribution.pdf
+    touch ${prefix}.wgs-coverage.pdf
+    """
+}

--- a/modules/nf-core/riker/multi/meta.yml
+++ b/modules/nf-core/riker/multi/meta.yml
@@ -1,0 +1,354 @@
+name: riker_multi
+description: |
+  Run multiple riker collectors in a single BAM pass using riker multi. Specify
+  tools via ext.args (e.g. '--tools alignment basic isize'). The wgs and gcbias
+  tools require a reference FASTA; the hybcap tool requires baits and targets.
+keywords:
+  - bam
+  - qc
+  - metrics
+  - multi
+  - alignment
+  - insert size
+  - gc bias
+  - coverage
+  - rna
+tools:
+  - riker:
+      description: |
+        Fast Rust CLI toolkit for sequencing QC metrics. Ports key QC metrics tools
+        from Picard with cleaner output and better performance.
+      homepage: https://github.com/fulcrumgenomics/riker
+      documentation: https://github.com/fulcrumgenomics/riker
+      licence: ["MIT"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - bam:
+        type: file
+        description: Aligned reads in BAM, CRAM, or SAM format
+        pattern: "*.{bam,cram,sam}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2572" # BAM
+          - edam: "http://edamontology.org/format_3462" # CRAM
+    - bai:
+        type: file
+        description: Index for the BAM/CRAM file
+        pattern: "*.{bai,crai}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3327" # BAI
+    - error_vcf:
+        type: file
+        description: VCF file containing known variants for error metrics. Must be bgzipped and indexed.
+        pattern: "*.vcf.gz"
+        ontologies:
+          - edam: "http://edamontology.org/format_3016" # VCF
+    - error_vcf_idx:
+        type: file
+        description: Index for the VCF file.
+        pattern: "*.vcf..gz.{tbi,csi}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3616" # TBI/CSI
+    - error_intervals:
+        type: file
+        description: IntervalList or BED file containing regions to exclude from error metrics. Optional.
+        pattern: "*.{interval_list,bed}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+    - gcbias_exclude_intervals:
+        type: file
+        description: IntervalList or BED file containing regions to exclude from GC bias metrics. Optional.
+        pattern: "*.{interval_list,bed}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+    - hybcap_baits:
+        type: file
+        description: Bait interval file (IntervalList or BED). Required when running the hybcap tool. Optional otherwise.
+        pattern: "*.{interval_list,bed}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+    - hybcap_targets:
+        type: file
+        description: Target interval file (IntervalList or BED). Required when running the hybcap tool. Optional otherwise.
+        pattern: "*.{interval_list,bed}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+    - rna_gene_model:
+        type: file
+        description: GTF or GFF file containing gene models. Required when running the rna tool. Optional otherwise.
+        pattern: "*.{gtf,gff}"
+        ontologies:
+          - edam: "http://edamontology.org/format_2306" # GTF
+          - edam: "http://edamontology.org/format_1975" # GFF
+    - rna_ribosomal_intervals:
+        type: file
+        description: Explicit ribosomal intervals (BED or Picard IntervalList), unioned with biotype-derived rRNA genes from the gene model
+        pattern: "*.{interval_list,bed}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+    - wgs_intervals:
+        type: file
+        description: IntervalList or BED file containing intervals for whole-genome coverage metrics. Required when running the wgs tool. Optional otherwise.
+        pattern: "*.{interval_list,bed}"
+        ontologies:
+          - edam: "http://edamontology.org/format_3003" # BED
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing reference information
+          e.g. [ id:'genome' ]
+    - fasta:
+        type: file
+        description: Reference genome FASTA file. Required when running wgs, gcbias, or error tools.
+        pattern: "*.{fa,fasta,fna}"
+        ontologies:
+          - edam: "http://edamontology.org/format_1929" # FASTA
+    - fai:
+        type: file
+        description: Index for the reference FASTA file
+        pattern: "*.fai"
+        ontologies:
+          - edam: "http://edamontology.org/format_3326" # FASTA index
+output:
+  alignment_metrics:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.alignment-metrics.txt":
+          type: file
+          description: Alignment summary metrics (alignment tool)
+          pattern: "*.alignment-metrics.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  base_dist:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.base-distribution-by-cycle.txt":
+          type: file
+          description: Base distribution by cycle (basic tool)
+          pattern: "*.base-distribution-by-cycle.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  error_indel:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.error-indel.txt":
+          type: file
+          description: Indel error metrics (error tool)
+          pattern: "*.error-indel.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  error_mismatch:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.error-mismatch.txt":
+          type: file
+          description: Base mismatch error metrics (error tool)
+          pattern: "*.error-mismatch.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  error_overlap:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.error-overlap.txt":
+          type: file
+          description: Read overlap error metrics (error tool)
+          pattern: "*.error-overlap.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  gcbias_detail:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.gcbias-detail.txt":
+          type: file
+          description: Per-GC-bin detail metrics (gcbias tool)
+          pattern: "*.gcbias-detail.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  gcbias_summary:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.gcbias-summary.txt":
+          type: file
+          description: GC bias summary metrics (gcbias tool)
+          pattern: "*.gcbias-summary.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  hybcap_metrics:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.hybcap-metrics.txt":
+          type: file
+          description: Hybrid capture summary metrics (hybcap tool)
+          pattern: "*.hybcap-metrics.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  hybcap_per_base:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.hybcap-per-base.txt*":
+          type: file
+          description: Per-base coverage values (hybcap tool, optional)
+          pattern: "*.hybcap-per-base.txt{,.gz}"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  hybcap_per_target:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.hybcap-per-target.txt":
+          type: file
+          description: Per-target coverage metrics (hybcap tool, optional)
+          pattern: "*.hybcap-per-target.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  isize_metrics:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.isize-metrics.txt":
+          type: file
+          description: Insert size summary metrics (isize tool)
+          pattern: "*.isize-metrics.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  isize_histogram:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.isize-histogram.txt":
+          type: file
+          description: Insert size histogram (isize tool)
+          pattern: "*.isize-histogram.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  mean_qual:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.mean-quality-by-cycle.txt":
+          type: file
+          description: Mean quality by cycle (basic tool)
+          pattern: "*.mean-quality-by-cycle.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  pdf:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.pdf":
+          type: file
+          description: PDF plots from any tool that generates them
+          pattern: "*.pdf"
+          ontologies:
+            - edam: "http://edamontology.org/format_3508" # PDF
+  qual_dist:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.quality-score-distribution.txt":
+          type: file
+          description: Quality score distribution (basic tool)
+          pattern: "*.quality-score-distribution.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  rna_biotype:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.rna-biotype.txt":
+          type: file
+          description: RNA biotype metrics (rna tool)
+          pattern: "*.rna-biotype.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  rna_insert_size:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.rna-insert-size.txt":
+          type: file
+          description: RNA insert size metrics (rna tool)
+          pattern: "*.rna-insert-size.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  rna_insert_size_histogram:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.rna-insert-size-histogram.txt":
+          type: file
+          description: RNA insert size histogram (rna tool)
+          pattern: "*.rna-insert-size-histogram.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  rna_metrics:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.rna-metrics.txt":
+          type: file
+          description: RNA summary metrics (rna tool)
+          pattern: "*.rna-metrics.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  wgs_metrics:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.wgs-metrics.txt":
+          type: file
+          description: Whole-genome coverage summary metrics (wgs tool)
+          pattern: "*.wgs-metrics.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  wgs_coverage:
+    - - meta:
+          type: map
+          description: Groovy Map containing sample information
+      - "*.wgs-coverage.txt":
+          type: file
+          description: Per-depth coverage histogram (wgs tool)
+          pattern: "*.wgs-coverage.txt"
+          ontologies:
+            - edam: "http://edamontology.org/format_3475" # TSV
+  versions_riker:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - riker:
+          type: string
+          description: The name of the tool
+      - riker --version 2>&1 | sed 's/riker //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - riker:
+          type: string
+          description: The name of the tool
+      - riker --version 2>&1 | sed 's/riker //':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@emmcauley"
+  - "@matthdsm"
+  - "@tfenne"
+maintainers:
+  - "@emmcauley"
+  - "@matthdsm"

--- a/modules/nf-core/riker/multi/riker-multi.diff
+++ b/modules/nf-core/riker/multi/riker-multi.diff
@@ -1,0 +1,59 @@
+Changes in component 'nf-core/riker/multi'
+'modules/nf-core/riker/multi/meta.yml' is unchanged
+'modules/nf-core/riker/multi/environment.yml' is unchanged
+Changes in 'riker/multi/main.nf':
+--- modules/nf-core/riker/multi/main.nf
++++ modules/nf-core/riker/multi/main.nf
+@@ -12,27 +12,27 @@
+     tuple val(meta2), path(fasta), path(fai)
+ 
+     output:
+-    tuple val(meta), path("*.alignment-metrics.txt"),          emit: alignment_metrics,         optional: true
+-    tuple val(meta), path("*.base-distribution-by-cycle.txt"), emit: base_dist,                 optional: true
+-    tuple val(meta), path("*.error-indel.txt"),                emit: error_indel,               optional: true
+-    tuple val(meta), path("*.error-mismatch.txt"),             emit: error_mismatch,            optional: true
+-    tuple val(meta), path("*.error-overlap.txt"),              emit: error_overlap,             optional: true
+-    tuple val(meta), path("*.gcbias-detail.txt"),              emit: gcbias_detail,             optional: true
+-    tuple val(meta), path("*.gcbias-summary.txt"),             emit: gcbias_summary,            optional: true
+-    tuple val(meta), path("*.hybcap-metrics.txt"),             emit: hybcap_metrics,            optional: true
+-    tuple val(meta), path("*.hybcap-per-base.txt*"),           emit: hybcap_per_base,           optional: true
+-    tuple val(meta), path("*.hybcap-per-target.txt"),          emit: hybcap_per_target,         optional: true
+-    tuple val(meta), path("*.isize-histogram.txt"),            emit: isize_histogram,           optional: true
+-    tuple val(meta), path("*.isize-metrics.txt"),              emit: isize_metrics,             optional: true
+-    tuple val(meta), path("*.mean-quality-by-cycle.txt"),      emit: mean_qual,                 optional: true
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.alignment-metrics.txt"),          emit: alignment_metrics,         optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.base-distribution-by-cycle.txt"), emit: base_dist,                 optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.error-indel.txt"),                emit: error_indel,               optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.error-mismatch.txt"),             emit: error_mismatch,            optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.error-overlap.txt"),              emit: error_overlap,             optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.gcbias-detail.txt"),              emit: gcbias_detail,             optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.gcbias-summary.txt"),             emit: gcbias_summary,            optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.hybcap-metrics.txt"),             emit: hybcap_metrics,            optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.hybcap-per-base.txt*"),           emit: hybcap_per_base,           optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.hybcap-per-target.txt"),          emit: hybcap_per_target,         optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.isize-histogram.txt"),            emit: isize_histogram,           optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.isize-metrics.txt"),              emit: isize_metrics,             optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.mean-quality-by-cycle.txt"),      emit: mean_qual,                 optional: true, topic: multiqc_files
+     tuple val(meta), path("*.pdf"),                            emit: pdf,                       optional: true
+-    tuple val(meta), path("*.quality-score-distribution.txt"), emit: qual_dist,                 optional: true
+-    tuple val(meta), path("*.rna-biotype.txt"),                emit: rna_biotype,               optional: true
+-    tuple val(meta), path("*.rna-insert-size-histogram.txt"),  emit: rna_insert_size_histogram, optional: true
+-    tuple val(meta), path("*.rna-insert-size.txt"),            emit: rna_insert_size,           optional: true
+-    tuple val(meta), path("*.rna-metrics.txt"),                emit: rna_metrics,               optional: true
+-    tuple val(meta), path("*.wgs-coverage.txt"),               emit: wgs_coverage,              optional: true
+-    tuple val(meta), path("*.wgs-metrics.txt"),                emit: wgs_metrics,               optional: true
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.quality-score-distribution.txt"), emit: qual_dist,                 optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-biotype.txt"),                emit: rna_biotype,               optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-insert-size-histogram.txt"),  emit: rna_insert_size_histogram, optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-insert-size.txt"),            emit: rna_insert_size,           optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.rna-metrics.txt"),                emit: rna_metrics,               optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.wgs-coverage.txt"),               emit: wgs_coverage,              optional: true, topic: multiqc_files
++    tuple val(meta), val("${task.process}"), val('riker'), path("*.wgs-metrics.txt"),                emit: wgs_metrics,               optional: true, topic: multiqc_files
+     tuple val("${task.process}"), val('riker'), eval("riker --version 2>&1 | sed 's/riker //'") , topic: versions, emit: versions_riker
+ 
+     when:
+
+'modules/nf-core/riker/multi/tests/main.nf.test' is unchanged
+'modules/nf-core/riker/multi/tests/nextflow.config' is unchanged
+'modules/nf-core/riker/multi/tests/main.nf.test.snap' is unchanged
+************************************************************

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -31,7 +31,7 @@
                 "tools": {
                     "type": "string",
                     "fa_icon": "fas fa-hammer",
-                    "description": "Specify which additional tools RNAvar should use. Values can be 'seq2hla', 'umitools', 'bcfann', 'snpeff', 'vep', 'riker' or 'merge'. If you specify 'merge', the pipeline runs both snpeff and VEP annotation.",
+                    "description": "Specify which additional tools RNAvar should use. Values can be 'seq2hla', 'umitools', 'riker', 'bcfann', 'snpeff', 'vep' or 'merge'. If you specify 'merge', the pipeline runs both snpeff and VEP annotation.",
                     "help_text": "List of opt-in tools to be used in addition to variant calling: currently umitools to remove UMIs from the reads with UMI-tools, hlatyping with Seq2HLA, riker for QC metrics, and a choice of annotation tools.",
                     "pattern": "^((umitools|seq2hla|riker|bcfann|snpeff|vep|merge)*(,)*)*$",
                     "hidden": true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -31,9 +31,9 @@
                 "tools": {
                     "type": "string",
                     "fa_icon": "fas fa-hammer",
-                    "description": "Specify which additional tools RNAvar should use. Values can be 'seq2hla', 'umitools', 'bcfann', 'snpeff', 'vep' or 'merge'. If you specify 'merge', the pipeline runs both snpeff and VEP annotation.",
-                    "help_text": "List of opt-in tools to be used in addition to variant calling: currently umitools to remove UMIs from the reads with UMI-tools, hlatyping with Seq2HLA, and a choice of annotation tools.",
-                    "pattern": "^((umitools|seq2hla|bcfann|snpeff|vep|merge)*(,)*)*$",
+                    "description": "Specify which additional tools RNAvar should use. Values can be 'seq2hla', 'umitools', 'bcfann', 'snpeff', 'vep', 'riker' or 'merge'. If you specify 'merge', the pipeline runs both snpeff and VEP annotation.",
+                    "help_text": "List of opt-in tools to be used in addition to variant calling: currently umitools to remove UMIs from the reads with UMI-tools, hlatyping with Seq2HLA, riker for QC metrics, and a choice of annotation tools.",
+                    "pattern": "^((umitools|seq2hla|riker|bcfann|snpeff|vep|merge)*(,)*)*$",
                     "hidden": true
                 },
                 "skip_tools": {

--- a/tests/tools_riker.nf.test
+++ b/tests/tools_riker.nf.test
@@ -1,0 +1,24 @@
+def projectDir = new File('.').absolutePath
+
+nextflow_pipeline {
+
+    name "Test pipeline"
+    script "../main.nf"
+    tag "pipeline"
+    tag "pipeline_rnavar"
+
+    def test_scenario = [
+        [
+            name: "-profile test --tools riker",
+            params: [
+                input: "${projectDir}/tests/csv/1.0/fastq_single.csv",
+                tools: 'riker',
+            ],
+        ],
+    ]
+
+    // Generate tests for each scenario
+    test_scenario.each { scenario ->
+        test(scenario.name, UTILS.getTest(scenario))
+    }
+}

--- a/tests/tools_riker.nf.test.snap
+++ b/tests/tools_riker.nf.test.snap
@@ -1,0 +1,255 @@
+{
+    "-profile test --tools riker": {
+        "content": [
+            44,
+            {
+                "CAT_FASTQ": {
+                    "cat": "9.5"
+                },
+                "FASTQC": {
+                    "fastqc": "0.12.1"
+                },
+                "GATK4_APPLYBQSR": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GATK4_BASERECALIBRATOR": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GATK4_BEDTOINTERVALLIST": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GATK4_HAPLOTYPECALLER": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GATK4_INTERVALLISTTOOLS": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GATK4_MERGEVCFS": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GATK4_SPLITNCIGARREADS": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GATK4_VARIANTFILTRATION": {
+                    "gatk4": "4.6.2.0"
+                },
+                "GFFREAD": {
+                    "gffread": "0.12.7"
+                },
+                "GTF2BED": {
+                    "Rscript": "3.5.1 (2018-07-02)"
+                },
+                "PICARD_MARKDUPLICATES": {
+                    "picard": "3.4.0"
+                },
+                "REMOVEUNKNOWNREGIONS": {
+                    "python": "3.8.3"
+                },
+                "RIKER_MULTI": {
+                    "riker": "0.4.0"
+                },
+                "SAMTOOLS_FAIDX": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_FLAGSTAT": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_IDXSTATS": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_INDEX": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_MERGE": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_SORT": {
+                    "samtools": "1.23.1"
+                },
+                "SAMTOOLS_STATS": {
+                    "samtools": "1.23.1"
+                },
+                "STAR_ALIGN": {
+                    "gawk": "5.1.0",
+                    "samtools": "1.21",
+                    "star": "2.7.11b"
+                },
+                "STAR_INDEXVERSION": {
+                    "star": "2.7.11b"
+                },
+                "TABIX_HAPLOTYPECALLER": {
+                    "htslib": "1.23.1",
+                    "xz": "5.8.3"
+                },
+                "UNTAR": {
+                    "untar": "1.34"
+                }
+            },
+            [
+                "pipeline_info",
+                "pipeline_info/nf_core_rnavar_software_mqc_versions.yml",
+                "preprocessing",
+                "preprocessing/GM12878",
+                "preprocessing/GM12878/GM12878.md.bam",
+                "preprocessing/GM12878/GM12878.md.bam.bai",
+                "preprocessing/GM12878/GM12878.recal.bam",
+                "preprocessing/GM12878/GM12878.recal.bam.bai",
+                "reports",
+                "reports/fastqc",
+                "reports/fastqc/GM12878",
+                "reports/fastqc/GM12878/GM12878_1_fastqc.html",
+                "reports/fastqc/GM12878/GM12878_1_fastqc.zip",
+                "reports/fastqc/GM12878/GM12878_2_fastqc.html",
+                "reports/fastqc/GM12878/GM12878_2_fastqc.zip",
+                "reports/multiqc",
+                "reports/multiqc/multiqc_data",
+                "reports/multiqc/multiqc_data/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Count.txt",
+                "reports/multiqc/multiqc_data/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Percent.txt",
+                "reports/multiqc/multiqc_data/gatk-base-recalibrator-reported-empirical-plot.txt",
+                "reports/multiqc/multiqc_data/gatk_base_recalibrator.txt",
+                "reports/multiqc/multiqc_data/llms-full.txt",
+                "reports/multiqc/multiqc_data/multiqc.log",
+                "reports/multiqc/multiqc_data/multiqc.parquet",
+                "reports/multiqc/multiqc_data/multiqc_citations.txt",
+                "reports/multiqc/multiqc_data/multiqc_data.json",
+                "reports/multiqc/multiqc_data/multiqc_general_stats.txt",
+                "reports/multiqc/multiqc_data/multiqc_picard_dups.txt",
+                "reports/multiqc/multiqc_data/multiqc_samtools_idxstats.txt",
+                "reports/multiqc/multiqc_data/multiqc_software_versions.txt",
+                "reports/multiqc/multiqc_data/multiqc_sources.txt",
+                "reports/multiqc/multiqc_data/multiqc_star.txt",
+                "reports/multiqc/multiqc_data/picard_MarkIlluminaAdapters_histogram.txt",
+                "reports/multiqc/multiqc_data/picard_MeanQualityByCycle_histogram.txt",
+                "reports/multiqc/multiqc_data/picard_MeanQualityByCycle_histogram_1.txt",
+                "reports/multiqc/multiqc_data/picard_QualityScoreDistribution_histogram.txt",
+                "reports/multiqc/multiqc_data/picard_deduplication.txt",
+                "reports/multiqc/multiqc_data/samtools-idxstats-mapped-reads-plot_Normalised_Counts.txt",
+                "reports/multiqc/multiqc_data/samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts.txt",
+                "reports/multiqc/multiqc_data/samtools-idxstats-mapped-reads-plot_Raw_Counts.txt",
+                "reports/multiqc/multiqc_data/star_alignment_plot.txt",
+                "reports/multiqc/multiqc_data/star_summary_table.txt",
+                "reports/multiqc/multiqc_plots",
+                "reports/multiqc/multiqc_plots/pdf",
+                "reports/multiqc/multiqc_plots/pdf/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Count.pdf",
+                "reports/multiqc/multiqc_plots/pdf/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Percent.pdf",
+                "reports/multiqc/multiqc_plots/pdf/gatk-base-recalibrator-reported-empirical-plot.pdf",
+                "reports/multiqc/multiqc_plots/pdf/picard_deduplication-cnt.pdf",
+                "reports/multiqc/multiqc_plots/pdf/picard_deduplication-pct.pdf",
+                "reports/multiqc/multiqc_plots/pdf/samtools-idxstats-mapped-reads-plot_Normalised_Counts-cnt.pdf",
+                "reports/multiqc/multiqc_plots/pdf/samtools-idxstats-mapped-reads-plot_Normalised_Counts-log.pdf",
+                "reports/multiqc/multiqc_plots/pdf/samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts-cnt.pdf",
+                "reports/multiqc/multiqc_plots/pdf/samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts-log.pdf",
+                "reports/multiqc/multiqc_plots/pdf/samtools-idxstats-mapped-reads-plot_Raw_Counts-cnt.pdf",
+                "reports/multiqc/multiqc_plots/pdf/samtools-idxstats-mapped-reads-plot_Raw_Counts-log.pdf",
+                "reports/multiqc/multiqc_plots/pdf/star_alignment_plot-cnt.pdf",
+                "reports/multiqc/multiqc_plots/pdf/star_alignment_plot-pct.pdf",
+                "reports/multiqc/multiqc_plots/pdf/star_summary_table.pdf",
+                "reports/multiqc/multiqc_plots/png",
+                "reports/multiqc/multiqc_plots/png/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Count.png",
+                "reports/multiqc/multiqc_plots/png/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Percent.png",
+                "reports/multiqc/multiqc_plots/png/gatk-base-recalibrator-reported-empirical-plot.png",
+                "reports/multiqc/multiqc_plots/png/picard_deduplication-cnt.png",
+                "reports/multiqc/multiqc_plots/png/picard_deduplication-pct.png",
+                "reports/multiqc/multiqc_plots/png/samtools-idxstats-mapped-reads-plot_Normalised_Counts-cnt.png",
+                "reports/multiqc/multiqc_plots/png/samtools-idxstats-mapped-reads-plot_Normalised_Counts-log.png",
+                "reports/multiqc/multiqc_plots/png/samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts-cnt.png",
+                "reports/multiqc/multiqc_plots/png/samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts-log.png",
+                "reports/multiqc/multiqc_plots/png/samtools-idxstats-mapped-reads-plot_Raw_Counts-cnt.png",
+                "reports/multiqc/multiqc_plots/png/samtools-idxstats-mapped-reads-plot_Raw_Counts-log.png",
+                "reports/multiqc/multiqc_plots/png/star_alignment_plot-cnt.png",
+                "reports/multiqc/multiqc_plots/png/star_alignment_plot-pct.png",
+                "reports/multiqc/multiqc_plots/png/star_summary_table.png",
+                "reports/multiqc/multiqc_plots/svg",
+                "reports/multiqc/multiqc_plots/svg/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Count.svg",
+                "reports/multiqc/multiqc_plots/svg/gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Percent.svg",
+                "reports/multiqc/multiqc_plots/svg/gatk-base-recalibrator-reported-empirical-plot.svg",
+                "reports/multiqc/multiqc_plots/svg/picard_deduplication-cnt.svg",
+                "reports/multiqc/multiqc_plots/svg/picard_deduplication-pct.svg",
+                "reports/multiqc/multiqc_plots/svg/samtools-idxstats-mapped-reads-plot_Normalised_Counts-cnt.svg",
+                "reports/multiqc/multiqc_plots/svg/samtools-idxstats-mapped-reads-plot_Normalised_Counts-log.svg",
+                "reports/multiqc/multiqc_plots/svg/samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts-cnt.svg",
+                "reports/multiqc/multiqc_plots/svg/samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts-log.svg",
+                "reports/multiqc/multiqc_plots/svg/samtools-idxstats-mapped-reads-plot_Raw_Counts-cnt.svg",
+                "reports/multiqc/multiqc_plots/svg/samtools-idxstats-mapped-reads-plot_Raw_Counts-log.svg",
+                "reports/multiqc/multiqc_plots/svg/star_alignment_plot-cnt.svg",
+                "reports/multiqc/multiqc_plots/svg/star_alignment_plot-pct.svg",
+                "reports/multiqc/multiqc_plots/svg/star_summary_table.svg",
+                "reports/multiqc/multiqc_report.html",
+                "reports/picard",
+                "reports/picard/GM12878",
+                "reports/picard/GM12878/GM12878.md.metrics.txt",
+                "reports/riker",
+                "reports/riker/GM12878",
+                "reports/riker/GM12878/GM12878.alignment-metrics.txt",
+                "reports/riker/GM12878/GM12878.base-distribution-by-cycle.txt",
+                "reports/riker/GM12878/GM12878.isize-histogram.txt",
+                "reports/riker/GM12878/GM12878.isize-metrics.txt",
+                "reports/riker/GM12878/GM12878.mean-quality-by-cycle.txt",
+                "reports/riker/GM12878/GM12878.quality-score-distribution.txt",
+                "reports/samtools",
+                "reports/samtools/GM12878",
+                "reports/samtools/GM12878/GM12878.aligned.flagstat",
+                "reports/samtools/GM12878/GM12878.aligned.idxstats",
+                "reports/samtools/GM12878/GM12878.aligned.stats",
+                "reports/samtools/GM12878/GM12878.md.flagstat",
+                "reports/samtools/GM12878/GM12878.md.idxstats",
+                "reports/samtools/GM12878/GM12878.md.stats",
+                "reports/samtools/GM12878/GM12878.recal.flagstat",
+                "reports/samtools/GM12878/GM12878.recal.idxstats",
+                "reports/samtools/GM12878/GM12878.recal.stats",
+                "reports/star",
+                "reports/star/GM12878",
+                "reports/star/GM12878/GM12878.Log.final.out",
+                "reports/star/GM12878/GM12878.Log.out",
+                "reports/star/GM12878/GM12878.Log.progress.out",
+                "reports/star/GM12878/GM12878.SJ.out.tab",
+                "variant_calling",
+                "variant_calling/GM12878",
+                "variant_calling/GM12878/GM12878.haplotypecaller.filtered.vcf.gz",
+                "variant_calling/GM12878/GM12878.haplotypecaller.filtered.vcf.gz.tbi",
+                "variant_calling/GM12878/GM12878.haplotypecaller.vcf.gz",
+                "variant_calling/GM12878/GM12878.haplotypecaller.vcf.gz.tbi"
+            ],
+            [
+                "gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Count.txt:md5,dfacb0327c15b3d267c21f197034dc3b",
+                "gatk-base-recalibrator-quality-scores-plot_Pre-recalibration_Percent.txt:md5,c1e12cf18f996c0729fa37b0ca17ca24",
+                "multiqc_citations.txt:md5,cf0010a27fe09ed8eabf89422df32550",
+                "multiqc_picard_dups.txt:md5,3c2ee70029b964a56b5eb0b2473eb147",
+                "multiqc_samtools_idxstats.txt:md5,244cd977a42595929ef61448eb7c86b8",
+                "multiqc_star.txt:md5,7e6521313553e98304f39d749df30dc6",
+                "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "picard_MeanQualityByCycle_histogram_1.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "picard_QualityScoreDistribution_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "samtools-idxstats-mapped-reads-plot_Normalised_Counts.txt:md5,0f26224af07ef7c66b94a804c9afd29b",
+                "samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts.txt:md5,0f26224af07ef7c66b94a804c9afd29b",
+                "samtools-idxstats-mapped-reads-plot_Raw_Counts.txt:md5,2c00bf09584c6eef7d052c8ed14f3948",
+                "star_alignment_plot.txt:md5,112fac650331136449a83b6764ec8f1d",
+                "star_summary_table.txt:md5,028b492d7fb5104dd0de21be819402aa",
+                "GM12878.alignment-metrics.txt:md5,1e0671f644bf5fbe6a4da1e30aecdcd8",
+                "GM12878.base-distribution-by-cycle.txt:md5,ff44e109c8b12cfe424293e357c8861b",
+                "GM12878.isize-histogram.txt:md5,853ab2863fe4788d4186b2311081b6e9",
+                "GM12878.isize-metrics.txt:md5,5561f39d7e91535210bd0e50cdea31c7",
+                "GM12878.mean-quality-by-cycle.txt:md5,6e952774640ea5a454caea0f03800819",
+                "GM12878.quality-score-distribution.txt:md5,7a848fa1d9d65e273f04b2eee2fc3ab4",
+                "GM12878.SJ.out.tab:md5,414fe118e884fddedd742cdac913803d"
+            ],
+            [
+                "GM12878.md.bam:md5,3a9888b45f85aa1d7515e0aad8215923",
+                "GM12878.recal.bam:md5,1078c5aa688c49bc1b15aea0801cfe44"
+            ],
+            "No unstable recal BAM files",
+            "No CRAM files",
+            [
+                "GM12878.haplotypecaller.filtered.vcf.gz:md5,d7724ad12ffb8b5d3a98763e52e20c22",
+                "GM12878.haplotypecaller.vcf.gz:md5,cc54a8cbfe0d47239cf12298d5da3b48"
+            ],
+            "No warnings"
+        ],
+        "timestamp": "2026-07-07T15:18:53.355663185",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    }
+}

--- a/workflows/rnavar.nf
+++ b/workflows/rnavar.nf
@@ -17,6 +17,7 @@ include { GATK4_VARIANTFILTRATION                    } from '../modules/nf-core/
 include { HTSLIB_BGZIPTABIX as TABIX_COMBINEGVCFS    } from '../modules/nf-core/htslib/bgziptabix'
 include { HTSLIB_BGZIPTABIX as TABIX_HAPLOTYPECALLER } from '../modules/nf-core/htslib/bgziptabix'
 include { MOSDEPTH                                   } from '../modules/nf-core/mosdepth'
+include { RIKER_MULTI                                } from '../modules/nf-core/riker/multi'
 include { SEQ2HLA                                    } from '../modules/nf-core/seq2hla'
 include { UMITOOLS_EXTRACT                           } from '../modules/nf-core/umitools/extract'
 
@@ -183,6 +184,13 @@ workflow RNAVAR {
         else {
             bam_variant_calling = SPLITNCIGAR.out.bam_bai
         }
+
+        // MODULE: Riker multi for QC metrics
+        // Runs QC metrics on BAM files using riker
+        RIKER_MULTI(
+            bam_variant_calling.combine(gtf).combine(exon_bed).map { meta, bam, bai, _meta_gtf, gtf_, _meta_exon_bed, exon_bed_ -> [meta, bam, bai, [], [], [], [], [], [], gtf_, [], exon_bed_] }.filter { 'riker' in tools },
+            fasta.join(fasta_fai).collect(),
+        )
 
         def haplotypecaller_interval_bam = bam_variant_calling
             .combine(interval_list_split)


### PR DESCRIPTION
Add riker multi module for QC metrics on BAM files.

## Changes

- Install riker/multi module from nf-core
- Integrate riker in workflow after variant calling
- Use existing GTF and exon_bed as inputs
- Add riker to tools pattern in schema
- Add test for riker

Generated via opencode
Verified and edited by @maxulysse 